### PR TITLE
Add formatted text output support to Python API

### DIFF
--- a/aslookup/cli.py
+++ b/aslookup/cli.py
@@ -14,17 +14,14 @@ from .lookup import get_as_data
 
 DEFAULT_LOOKUP_SOURCE = "cymru"
 
-logging.basicConfig(
-    level=logging.DEBUG, format="[%(levelname)s] %(message)s"
-)
+logging.basicConfig(level=logging.DEBUG, format="[%(levelname)s] %(message)s")
 logger = logging.getLogger(__name__)
 
 
 def main():
     """Run main CLI."""
     description = (
-        "Client to return autonomous system information for "
-        "IPv4 addresses"
+        "Client to return autonomous system information for IPv4 addresses"
     )
     epilog = (
         "One or more IP addresses may be passed as arguments on the "

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "aslookup"
-version = "1.5.2"
+version = "1.6.0"
 authors = [
     { name="Darren Spruell", email="phatbuckett@gmail.com" },
 ]

--- a/tox.ini
+++ b/tox.ini
@@ -17,7 +17,7 @@ skip_install = true
 deps =
     black
 commands =
-    black -l 76 {posargs:aslookup}
+    black -l 79 {posargs:aslookup}
 
 [testenv:lint]
 description = run linters


### PR DESCRIPTION
- Add `ASData.as_text()` to return a formatted text representation of the AS lookup data
- Add the queried IP address as a data field

Closes #5.