### PR TITLE
Issue 0012 async

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -105,3 +105,7 @@ venv.bak/
 
 # editor
 *.sw[a-z]
+
+# Agents
+AGENTS.md
+CLAUDE.md

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ operated by the following organizations:
 * Team Cymru -- http://www.team-cymru.org/IP-ASN-mapping.html
 
 The client implements both a simple Python module (aslookup) as well as a CLI
-utility (`as-lookup`). The lookups are done using DNS with asynchronous 
+utility (`as-lookup`). The lookups are done using DNS with asynchronous
 processing for improved performance when handling multiple IP addresses.
 
 Both IPv4 and IPv6 addresses are supported. The client also maintains a
@@ -19,12 +19,11 @@ user on the address.
 
 ## Performance
 
-Starting with version 2.0.0, aslookup uses asynchronous DNS lookups to 
-significantly improve performance when processing multiple IP addresses. 
-The tool automatically processes multiple addresses concurrently (up to 15 
-simultaneous requests by default) while maintaining the same CLI interface 
-and output format. This provides substantial speed improvements for bulk 
-lookups without requiring any changes to existing usage patterns.
+Starting with version 2.0.0, aslookup uses asynchronous DNS lookups to
+improve performance when processing multiple IP addresses.  The tool
+automatically processes multiple addresses concurrently (up to 15
+simultaneous requests by default) while maintaining the same CLI interface
+and output format.
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -8,15 +8,23 @@ operated by the following organizations:
 * Team Cymru -- http://www.team-cymru.org/IP-ASN-mapping.html
 
 The client implements both a simple Python module (aslookup) as well as a CLI
-utility (`as-lookup`). The lookups are currently done using DNS, which works
-well for a one-off lookups. It is not optimized for bulk lookups over the
-Whois protocol.
+utility (`as-lookup`). The lookups are done using DNS with asynchronous 
+processing for improved performance when handling multiple IP addresses.
 
 Both IPv4 and IPv6 addresses are supported. The client also maintains a
 listing of IP networks which are unroutable internet addresses, typically
 in special use RFC ranges. In this way it can both filter out addresses
 from queries which are a waste of time, as well as provide context to the
 user on the address.
+
+## Performance
+
+Starting with version 2.0.0, aslookup uses asynchronous DNS lookups to 
+significantly improve performance when processing multiple IP addresses. 
+The tool automatically processes multiple addresses concurrently (up to 15 
+simultaneous requests by default) while maintaining the same CLI interface 
+and output format. This provides substantial speed improvements for bulk 
+lookups without requiring any changes to existing usage patterns.
 
 ## Installation
 
@@ -70,4 +78,3 @@ This can be useful to validate included IP prefix classifications and see the
 output format.
 
     as-lookup < tests/test_input.txt
-

--- a/aslookup/cli.py
+++ b/aslookup/cli.py
@@ -15,7 +15,8 @@ from .lookup import get_as_data_async
 DEFAULT_LOOKUP_SOURCE = "cymru"
 
 logging.basicConfig(
-    level=logging.WARNING, format="[%(levelname)s] %(name)s: %(message)s"
+    level=logging.WARNING,
+    format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
 )
 logger = logging.getLogger("aslookup")
 

--- a/aslookup/lookup.py
+++ b/aslookup/lookup.py
@@ -1,6 +1,5 @@
 """Lookup routines."""
 
-import asyncio
 import logging
 import re
 from collections import namedtuple
@@ -371,7 +370,7 @@ def get_as_data(addr, service="shadowserver"):
 async def get_as_data_async(addr, service="shadowserver"):
     """
     Async version of get_as_data().
-    
+
     Query and return AS information for supplied IP address using async DNS.
     """
     # Remove leading or trailing whitespace and/or defanging of input
@@ -403,7 +402,7 @@ async def get_as_data_async(addr, service="shadowserver"):
 
     # Create async DNS resolver
     resolver = aiodns.DNSResolver()
-    
+
     try:
         # Perform async DNS query
         answers = await resolver.query(origin_addr, "TXT")

--- a/aslookup/lookup.py
+++ b/aslookup/lookup.py
@@ -306,6 +306,7 @@ def get_as_data(addr, service="shadowserver"):
         )
 
     try:
+        logger.debug("issuing DNS query for %s", origin_addr)
         answers = dns.resolver.query(origin_addr, "TXT")
     except dns.resolver.NXDOMAIN:
         raise NoASDataError("No routing origin data for address")
@@ -356,6 +357,7 @@ def get_as_data(addr, service="shadowserver"):
             _sfx = AS_SERVICES[service]["as_description_suffix"]
             as_data_addr = f"AS{m1.group(0)}.{_sfx}"
             try:
+                logger.debug("issuing DNS query for %s", origin_addr)
                 answers = dns.resolver.query(as_data_addr, "TXT")
             except dns.resolver.NXDOMAIN:
                 raise NoASDataError("No routing origin data for address")
@@ -405,6 +407,7 @@ async def get_as_data_async(addr, service="shadowserver"):
 
     try:
         # Perform async DNS query
+        logger.debug("issuing DNS query for %s", origin_addr)
         answers = await resolver.query(origin_addr, "TXT")
     except aiodns.error.DNSError:
         raise NoASDataError("No routing origin data for address")
@@ -455,6 +458,7 @@ async def get_as_data_async(addr, service="shadowserver"):
             _sfx = AS_SERVICES[service]["as_description_suffix"]
             as_data_addr = f"AS{m1.group(0)}.{_sfx}"
             try:
+                logger.debug("issuing DNS query for %s", origin_addr)
                 answers = await resolver.query(as_data_addr, "TXT")
             except aiodns.error.DNSError:
                 raise NoASDataError("No routing origin data for address")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,14 @@ classifiers = [
 [project.scripts]
 as-lookup = "aslookup.cli:main"
 
+[project.optional-dependencies]
+test = [
+    "pytest",
+    "pytest-asyncio",
+    "pytest-mock",
+    "pytest-cov",
+]
+
 [project.urls]
 "Bug Tracker" = "https://github.com/dspruell/aslookup/issues"
 "Homepage" = "https://github.com/dspruell/aslookup"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,13 +4,14 @@ build-backend = "hatchling.build"
 
 [project]
 name = "aslookup"
-version = "1.7.0"
+version = "2.0.0"
 authors = [
     { name="Darren Spruell", email="phatbuckett@gmail.com" },
 ]
 description = "IP to ASN routing data query script"
 readme = "README.md"
 dependencies = [
+    "aiodns",
     "defang",
     "dnspython",
     "pytricia",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,122 @@
+"""Shared test fixtures and configuration."""
+
+import pytest
+from unittest.mock import Mock, MagicMock
+from aslookup.lookup import ASData
+
+
+@pytest.fixture
+def sample_ipv4_address():
+    """Sample IPv4 address for testing."""
+    return "8.8.8.8"
+
+
+@pytest.fixture
+def sample_ipv6_address():
+    """Sample IPv6 address for testing."""
+    return "2001:4860:4860::8888"
+
+
+@pytest.fixture
+def invalid_ip_addresses():
+    """List of invalid IP addresses for testing."""
+    return [
+        "256.256.256.256",  # Invalid IPv4
+        "192.168.1",        # Incomplete IPv4
+        "a.b.c.d",          # Non-numeric IPv4
+        "gggg::1",          # Invalid IPv6
+        "not_an_ip",        # Not an IP at all
+        "",                 # Empty string
+        "   ",              # Whitespace only
+    ]
+
+
+@pytest.fixture
+def private_ip_addresses():
+    """List of private/non-routable IP addresses."""
+    return [
+        "192.168.1.1",      # RFC 1918
+        "10.0.0.1",         # RFC 1918
+        "172.16.0.1",       # RFC 1918
+        "127.0.0.1",        # Loopback
+        "169.254.1.1",      # Link local
+        "224.0.0.1",        # Multicast
+        "::1",              # IPv6 loopback
+        "fe80::1",          # IPv6 link local
+        "fc00::1",          # IPv6 unique local
+        "2001:db8::1",      # IPv6 documentation
+    ]
+
+
+@pytest.fixture
+def sample_shadowserver_response():
+    """Sample Shadowserver DNS TXT response."""
+    return '"15133 | 8.8.8.0/24 | GOOGLE | US | Google LLC"'
+
+
+@pytest.fixture
+def sample_cymru_origin_response():
+    """Sample Team Cymru origin DNS TXT response."""
+    return '"15169 | 8.8.8.0/24 | US | arin | 2000-03-30"'
+
+
+@pytest.fixture
+def sample_cymru_asn_response():
+    """Sample Team Cymru ASN description DNS TXT response."""
+    return '"15169 | US | arin | 2000-03-30 | GOOGLE, US"'
+
+
+@pytest.fixture
+def sample_asdata_shadowserver():
+    """Sample ASData object from Shadowserver."""
+    return ASData(
+        address="8.8.8.8",
+        handle="AS15133",
+        asn="15133",
+        as_name="Google LLC",
+        rir=None,
+        reg_date=None,
+        prefix="8.8.8.0/24",
+        cc="US",
+        domain=None,
+        isp="Google LLC",
+        data_source="shadowserver",
+    )
+
+
+@pytest.fixture
+def sample_asdata_cymru():
+    """Sample ASData object from Team Cymru."""
+    return ASData(
+        address="8.8.8.8",
+        handle="AS15169",
+        asn="15169",
+        as_name="GOOGLE, US",
+        rir="arin",
+        reg_date="2000-03-30",
+        prefix="8.8.8.0/24",
+        cc="US",
+        domain=None,
+        isp=None,
+        data_source="cymru",
+    )
+
+
+@pytest.fixture
+def mock_dns_resolver():
+    """Mock DNS resolver for testing."""
+    mock_resolver = Mock()
+    mock_answer = Mock()
+    mock_answer.to_text.return_value = '"15133 | 8.8.8.0/24 | GOOGLE | US | Google LLC"'
+    mock_resolver.query.return_value = [mock_answer]
+    return mock_resolver
+
+
+@pytest.fixture
+def mock_async_dns_resolver():
+    """Mock async DNS resolver for testing."""
+    mock_resolver = Mock()
+    mock_answer = Mock()
+    mock_answer.text = '"15133 | 8.8.8.0/24 | GOOGLE | US | Google LLC"'
+    mock_resolver.query.return_value = [mock_answer]
+    return mock_resolver

--- a/tests/test_asdata.py
+++ b/tests/test_asdata.py
@@ -1,0 +1,351 @@
+"""Tests for ASData namedtuple structure."""
+
+import pytest
+
+from aslookup.lookup import ASData
+
+
+class TestASDataCreation:
+    """Test ASData namedtuple creation and basic functionality."""
+
+    def test_asdata_creation_with_all_fields(self):
+        """Test creating ASData with all fields populated."""
+        data = ASData(
+            address="8.8.8.8",
+            handle="AS15169",
+            asn="15169",
+            as_name="GOOGLE",
+            rir="arin",
+            reg_date="2000-03-30",
+            prefix="8.8.8.0/24",
+            cc="US",
+            domain="google.com",
+            isp="Google LLC",
+            data_source="cymru",
+        )
+
+        assert data.address == "8.8.8.8"
+        assert data.handle == "AS15169"
+        assert data.asn == "15169"
+        assert data.as_name == "GOOGLE"
+        assert data.rir == "arin"
+        assert data.reg_date == "2000-03-30"
+        assert data.prefix == "8.8.8.0/24"
+        assert data.cc == "US"
+        assert data.domain == "google.com"
+        assert data.isp == "Google LLC"
+        assert data.data_source == "cymru"
+
+    def test_asdata_creation_with_none_values(self):
+        """Test creating ASData with None values for optional fields."""
+        data = ASData(
+            address="8.8.8.8",
+            handle="AS15169",
+            asn="15169",
+            as_name="GOOGLE",
+            rir=None,
+            reg_date=None,
+            prefix="8.8.8.0/24",
+            cc="US",
+            domain=None,
+            isp=None,
+            data_source="shadowserver",
+        )
+
+        assert data.address == "8.8.8.8"
+        assert data.rir is None
+        assert data.reg_date is None
+        assert data.domain is None
+        assert data.isp is None
+
+    def test_asdata_immutability(self):
+        """Test that ASData is immutable (namedtuple property)."""
+        data = ASData(
+            address="8.8.8.8",
+            handle="AS15169",
+            asn="15169",
+            as_name="GOOGLE",
+            rir="arin",
+            reg_date="2000-03-30",
+            prefix="8.8.8.0/24",
+            cc="US",
+            domain="google.com",
+            isp="Google LLC",
+            data_source="cymru",
+        )
+
+        # Should not be able to modify fields
+        with pytest.raises(AttributeError):
+            data.address = "1.1.1.1"
+
+        with pytest.raises(AttributeError):
+            data.asn = "12345"
+
+    def test_asdata_field_access(self):
+        """Test accessing ASData fields by name."""
+        data = ASData(
+            address="192.0.2.1",
+            handle="AS64496",
+            asn="64496",
+            as_name="TEST-AS",
+            rir="ripe",
+            reg_date="2020-01-01",
+            prefix="192.0.2.0/24",
+            cc="NL",
+            domain="example.org",
+            isp="Test ISP",
+            data_source="cymru",
+        )
+
+        # Test all field access
+        assert hasattr(data, 'address')
+        assert hasattr(data, 'handle')
+        assert hasattr(data, 'asn')
+        assert hasattr(data, 'as_name')
+        assert hasattr(data, 'rir')
+        assert hasattr(data, 'reg_date')
+        assert hasattr(data, 'prefix')
+        assert hasattr(data, 'cc')
+        assert hasattr(data, 'domain')
+        assert hasattr(data, 'isp')
+        assert hasattr(data, 'data_source')
+
+
+class TestASDataMethods:
+    """Test ASData methods and functionality."""
+
+    def test_as_text_method_basic(self, sample_asdata_shadowserver):
+        """Test as_text method with basic data."""
+        result = sample_asdata_shadowserver.as_text()
+        expected = "8.8.8.8          AS15133 | US | Google LLC"
+        assert result == expected
+
+    def test_as_text_method_formatting(self):
+        """Test as_text method formatting with different data."""
+        data = ASData(
+            address="2001:db8::1",
+            handle="AS64512",
+            asn="64512",
+            as_name="EXAMPLE-AS",
+            rir="arin",
+            reg_date="2021-06-15",
+            prefix="2001:db8::/32",
+            cc="CA",
+            domain="example.ca",
+            isp="Example ISP",
+            data_source="cymru",
+        )
+
+        result = data.as_text()
+        expected = "2001:db8::1      AS64512 | CA | EXAMPLE-AS"
+        assert result == expected
+
+    def test_as_text_method_with_long_address(self):
+        """Test as_text method with long IPv6 address."""
+        data = ASData(
+            address="2001:0db8:85a3:0000:0000:8a2e:0370:7334",
+            handle="AS65001",
+            asn="65001",
+            as_name="LONG-ADDRESS-TEST",
+            rir="ripe",
+            reg_date="2019-12-31",
+            prefix="2001:db8:85a3::/48",
+            cc="DE",
+            domain=None,
+            isp=None,
+            data_source="shadowserver",
+        )
+
+        result = data.as_text()
+        # Should handle long addresses gracefully
+        assert "2001:0db8:85a3:0000:0000:8a2e:0370:7334" in result
+        assert "AS65001" in result
+        assert "DE" in result
+        assert "LONG-ADDRESS-TEST" in result
+
+    def test_as_text_method_with_none_values(self):
+        """Test as_text method when some fields are None."""
+        data = ASData(
+            address="10.0.0.1",
+            handle="AS65000",
+            asn="65000",
+            as_name="PRIVATE-AS",
+            rir=None,
+            reg_date=None,
+            prefix=None,
+            cc="XX",
+            domain=None,
+            isp=None,
+            data_source="test",
+        )
+
+        result = data.as_text()
+        # Should handle None values without crashing
+        assert "10.0.0.1" in result
+        assert "AS65000" in result
+        assert "XX" in result
+        assert "PRIVATE-AS" in result
+
+
+class TestASDataComparison:
+    """Test ASData comparison and equality."""
+
+    def test_asdata_equality(self):
+        """Test ASData equality comparison."""
+        data1 = ASData(
+            address="8.8.8.8",
+            handle="AS15169",
+            asn="15169",
+            as_name="GOOGLE",
+            rir="arin",
+            reg_date="2000-03-30",
+            prefix="8.8.8.0/24",
+            cc="US",
+            domain="google.com",
+            isp="Google LLC",
+            data_source="cymru",
+        )
+
+        data2 = ASData(
+            address="8.8.8.8",
+            handle="AS15169",
+            asn="15169",
+            as_name="GOOGLE",
+            rir="arin",
+            reg_date="2000-03-30",
+            prefix="8.8.8.0/24",
+            cc="US",
+            domain="google.com",
+            isp="Google LLC",
+            data_source="cymru",
+        )
+
+        assert data1 == data2
+
+    def test_asdata_inequality(self):
+        """Test ASData inequality comparison."""
+        data1 = ASData(
+            address="8.8.8.8",
+            handle="AS15169",
+            asn="15169",
+            as_name="GOOGLE",
+            rir="arin",
+            reg_date="2000-03-30",
+            prefix="8.8.8.0/24",
+            cc="US",
+            domain="google.com",
+            isp="Google LLC",
+            data_source="cymru",
+        )
+
+        data2 = ASData(
+            address="1.1.1.1",  # Different address
+            handle="AS13335",
+            asn="13335",
+            as_name="CLOUDFLARE",
+            rir="arin",
+            reg_date="2010-07-14",
+            prefix="1.1.1.0/24",
+            cc="US",
+            domain="cloudflare.com",
+            isp="Cloudflare Inc",
+            data_source="shadowserver",
+        )
+
+        assert data1 != data2
+
+    def test_asdata_hash(self):
+        """Test ASData can be hashed (for use in sets/dicts)."""
+        data = ASData(
+            address="8.8.8.8",
+            handle="AS15169",
+            asn="15169",
+            as_name="GOOGLE",
+            rir="arin",
+            reg_date="2000-03-30",
+            prefix="8.8.8.0/24",
+            cc="US",
+            domain="google.com",
+            isp="Google LLC",
+            data_source="cymru",
+        )
+
+        # Should be able to hash the object
+        hash_value = hash(data)
+        assert isinstance(hash_value, int)
+
+        # Should be able to use in set
+        data_set = {data}
+        assert len(data_set) == 1
+        assert data in data_set
+
+        # Should be able to use as dict key
+        data_dict = {data: "test_value"}
+        assert data_dict[data] == "test_value"
+
+
+class TestASDataRepresentation:
+    """Test ASData string representation and debugging."""
+
+    def test_asdata_str_representation(self, sample_asdata_cymru):
+        """Test string representation of ASData."""
+        str_repr = str(sample_asdata_cymru)
+        # Should contain the class name and field values
+        assert "ASData" in str_repr
+        assert "8.8.8.8" in str_repr
+        assert "AS15169" in str_repr
+
+    def test_asdata_repr_representation(self, sample_asdata_shadowserver):
+        """Test repr representation of ASData."""
+        repr_str = repr(sample_asdata_shadowserver)
+        # Should be a valid Python expression that could recreate the object
+        assert "ASData" in repr_str
+        assert "address=" in repr_str
+        assert "handle=" in repr_str
+        assert "data_source=" in repr_str
+
+    def test_asdata_field_iteration(self):
+        """Test iterating over ASData fields."""
+        data = ASData(
+            address="203.0.113.1",
+            handle="AS64497",
+            asn="64497",
+            as_name="DOC-AS",
+            rir="arin",
+            reg_date="2022-01-01",
+            prefix="203.0.113.0/24",
+            cc="US",
+            domain="documentation.example",
+            isp="Documentation ISP",
+            data_source="test",
+        )
+
+        # Should be able to iterate over fields
+        fields = list(data)
+        assert len(fields) == 11  # Number of fields in ASData
+        assert fields[0] == "203.0.113.1"  # address
+        assert fields[1] == "AS64497"      # handle
+        assert fields[2] == "64497"        # asn
+
+    def test_asdata_field_names(self):
+        """Test accessing field names."""
+        data = ASData(
+            address="198.51.100.1",
+            handle="AS64498",
+            asn="64498",
+            as_name="TEST2-AS",
+            rir="ripe",
+            reg_date="2023-01-01",
+            prefix="198.51.100.0/24",
+            cc="GB",
+            domain="test2.example",
+            isp="Test2 ISP",
+            data_source="cymru",
+        )
+
+        # Should have _fields attribute with field names
+        expected_fields = (
+            'address', 'handle', 'asn', 'as_name', 'rir', 'reg_date',
+            'prefix', 'cc', 'domain', 'isp', 'data_source'
+        )
+        assert data._fields == expected_fields

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,407 @@
+"""Tests for aslookup.cli module."""
+
+import asyncio
+import sys
+from io import StringIO
+from unittest.mock import Mock, patch
+
+import pytest
+
+from aslookup.cli import main, process_addresses_async, process_single_address
+from aslookup.exceptions import AddressFormatError, LookupError
+from aslookup.lookup import ASData
+
+
+class TestCLIArgumentParsing:
+    """Test CLI argument parsing functionality."""
+
+    def test_basic_argument_parsing(self):
+        """Test basic argument parsing with single IP."""
+        with patch('aslookup.cli.asyncio.run') as mock_asyncio_run:
+            with patch('sys.argv', ['as-lookup', '8.8.8.8']):
+                with patch('aslookup.cli.process_addresses_async') as mock_process:
+                    # Mock the async function to avoid coroutine warnings
+                    mock_process.return_value = asyncio.Future()
+                    mock_process.return_value.set_result(None)
+                    
+                    main()
+                    mock_asyncio_run.assert_called_once()
+
+    def test_service_argument_parsing(self):
+        """Test service argument parsing."""
+        with patch('aslookup.cli.asyncio.run') as mock_asyncio_run:
+            with patch('sys.argv', ['as-lookup', '--service', 'shadowserver', '8.8.8.8']):
+                with patch('aslookup.cli.process_addresses_async') as mock_process:
+                    mock_process.return_value = asyncio.Future()
+                    mock_process.return_value.set_result(None)
+                    
+                    main()
+                    mock_asyncio_run.assert_called_once()
+
+    def test_header_argument_parsing(self):
+        """Test header argument parsing."""
+        with patch('aslookup.cli.asyncio.run') as mock_asyncio_run:
+            with patch('sys.argv', ['as-lookup', '--header', '8.8.8.8']):
+                with patch('aslookup.cli.process_addresses_async') as mock_process:
+                    mock_process.return_value = asyncio.Future()
+                    mock_process.return_value.set_result(None)
+                    
+                    with patch('builtins.print') as mock_print:
+                        main()
+                        
+                        # Should print header
+                        mock_print.assert_any_call('-' * 50)
+                        mock_print.assert_any_call('%-15s  %s' % ('IP Address',
+                                                                  'AS Information'))
+
+    def test_raw_argument_parsing(self):
+        """Test raw output argument parsing."""
+        with patch('aslookup.cli.asyncio.run') as mock_asyncio_run:
+            with patch('sys.argv', ['as-lookup', '--raw', '8.8.8.8']):
+                with patch('aslookup.cli.process_addresses_async') as mock_process:
+                    mock_process.return_value = asyncio.Future()
+                    mock_process.return_value.set_result(None)
+                    
+                    main()
+                    mock_asyncio_run.assert_called_once()
+
+    def test_verbose_argument_parsing(self):
+        """Test verbose argument parsing."""
+        with patch('aslookup.cli.asyncio.run') as mock_asyncio_run:
+            with patch('sys.argv', ['as-lookup', '--verbose', '8.8.8.8']):
+                with patch('aslookup.cli.process_addresses_async') as mock_process:
+                    mock_process.return_value = asyncio.Future()
+                    mock_process.return_value.set_result(None)
+                    
+                    main()
+                    mock_asyncio_run.assert_called_once()
+
+    def test_version_argument(self):
+        """Test version argument exits with version info."""
+        with patch('sys.argv', ['as-lookup', '--version']):
+            with pytest.raises(SystemExit) as exc_info:
+                with patch('sys.stderr', new_callable=StringIO) as mock_stderr:
+                    main()
+
+            assert exc_info.value.code == 0
+            output = mock_stderr.getvalue()
+            assert "aslookup" in output
+
+    def test_multiple_addresses_argument(self):
+        """Test multiple IP addresses as arguments."""
+        with patch('aslookup.cli.asyncio.run') as mock_asyncio_run:
+            with patch('sys.argv', ['as-lookup', '8.8.8.8', '1.1.1.1']):
+                with patch('aslookup.cli.process_addresses_async') as mock_process:
+                    mock_process.return_value = asyncio.Future()
+                    mock_process.return_value.set_result(None)
+                    
+                    main()
+                    mock_asyncio_run.assert_called_once()
+
+    def test_invalid_service_argument(self):
+        """Test invalid service argument."""
+        with patch('sys.argv', ['as-lookup', '--service', 'invalid']):
+            with pytest.raises(SystemExit):
+                main()
+
+
+class TestProcessSingleAddress:
+    """Test processing single address functionality."""
+
+    @pytest.mark.asyncio
+    async def test_process_single_address_success(self, sample_asdata_shadowserver):
+        """Test successful processing of single address."""
+        with patch('aslookup.cli.get_as_data_async') as mock_get_data:
+            mock_get_data.return_value = sample_asdata_shadowserver
+            
+            result = await process_single_address("8.8.8.8", "shadowserver", False)
+            addr, out_str, error, stream = result
+            
+            assert addr == "8.8.8.8"
+            assert "AS15133" in out_str
+            assert "US" in out_str
+            assert "Google LLC" in out_str
+            assert error is None
+            assert stream == sys.stdout
+
+    @pytest.mark.asyncio
+    async def test_process_single_address_raw_output(self, sample_asdata_cymru):
+        """Test processing single address with raw output."""
+        with patch('aslookup.cli.get_as_data_async') as mock_get_data:
+            mock_get_data.return_value = sample_asdata_cymru
+            
+            result = await process_single_address("8.8.8.8", "cymru", True)
+            addr, data, error, stream = result
+            
+            assert addr == "8.8.8.8"
+            assert data == sample_asdata_cymru
+            assert error is None
+            assert stream == sys.stdout
+
+    @pytest.mark.asyncio
+    async def test_process_single_address_format_error(self):
+        """Test processing single address with format error."""
+        with patch('aslookup.cli.get_as_data_async') as mock_get_data:
+            mock_get_data.side_effect = AddressFormatError("Invalid IP")
+            
+            result = await process_single_address("invalid_ip", "shadowserver", False)
+            addr, error_msg, error, stream = result
+            
+            assert addr == "invalid_ip"
+            assert "Invalid IP" in error_msg
+            assert isinstance(error, AddressFormatError)
+            assert stream == sys.stderr
+
+    @pytest.mark.asyncio
+    async def test_process_single_address_lookup_error(self):
+        """Test processing single address with lookup error."""
+        with patch('aslookup.cli.get_as_data_async') as mock_get_data:
+            mock_get_data.side_effect = LookupError("No data found")
+            
+            result = await process_single_address("192.168.1.1", "shadowserver", False)
+            addr, error_msg, error, stream = result
+            
+            assert addr == "192.168.1.1"
+            assert "No data found" in error_msg
+            assert isinstance(error, LookupError)
+            assert stream == sys.stderr
+
+
+class TestProcessAddressesAsync:
+    """Test async address processing functionality."""
+
+    @pytest.mark.asyncio
+    async def test_process_addresses_empty_list(self):
+        """Test processing empty address list."""
+        # Create mock args object
+        args = Mock()
+        args.service = "shadowserver"
+        args.raw = False
+        args.pause = False
+        args.address = []
+        
+        parser = Mock()
+        
+        # Should return without error
+        await process_addresses_async([], args, parser)
+
+    @pytest.mark.asyncio
+    async def test_process_addresses_single_cmdline_success(self, sample_asdata_shadowserver):
+        """Test processing single address from command line successfully."""
+        with patch('aslookup.cli.get_as_data_async') as mock_get_data:
+            with patch('builtins.print') as mock_print:
+                mock_get_data.return_value = sample_asdata_shadowserver
+                
+                args = Mock()
+                args.service = "shadowserver"
+                args.raw = False
+                args.pause = False
+                args.address = ["8.8.8.8"]
+                
+                parser = Mock()
+                
+                await process_addresses_async(["8.8.8.8"], args, parser)
+                
+                # Should print the result
+                mock_print.assert_called()
+                output = str(mock_print.call_args)
+                assert "8.8.8.8" in output
+
+    @pytest.mark.asyncio
+    async def test_process_addresses_single_cmdline_error(self):
+        """Test processing single address from command line with error."""
+        with patch('aslookup.cli.get_as_data_async') as mock_get_data:
+            mock_get_data.side_effect = AddressFormatError("Invalid IP")
+            
+            args = Mock()
+            args.service = "shadowserver"
+            args.raw = False
+            args.pause = False
+            args.address = ["invalid_ip"]
+            
+            parser = Mock()
+            parser.error = Mock()
+            
+            await process_addresses_async(["invalid_ip"], args, parser)
+            
+            # Should call parser.error
+            parser.error.assert_called_once()
+            call_args = parser.error.call_args[0][0]
+            assert "invalid_ip" in call_args
+            assert "Invalid IP" in call_args
+
+    @pytest.mark.asyncio
+    async def test_process_addresses_multiple_concurrent(self, sample_asdata_shadowserver,
+                                                        sample_asdata_cymru):
+        """Test processing multiple addresses concurrently."""
+        with patch('aslookup.cli.get_as_data_async') as mock_get_data:
+            with patch('builtins.print') as mock_print:
+                # Return different data for different IPs
+                def side_effect(addr, service):
+                    if addr == "8.8.8.8":
+                        return sample_asdata_shadowserver
+                    else:
+                        return sample_asdata_cymru
+                
+                mock_get_data.side_effect = side_effect
+                
+                args = Mock()
+                args.service = "shadowserver"
+                args.raw = False
+                args.pause = False
+                args.address = None  # Indicates stdin input
+                
+                parser = Mock()
+                
+                addresses = ["8.8.8.8", "1.1.1.1"]
+                await process_addresses_async(addresses, args, parser)
+                
+                # Should print results for both addresses
+                assert mock_print.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_process_addresses_with_pause(self, sample_asdata_shadowserver):
+        """Test processing addresses with pause between requests."""
+        with patch('aslookup.cli.get_as_data_async') as mock_get_data:
+            with patch('builtins.print'):
+                with patch('asyncio.sleep') as mock_sleep:
+                    mock_get_data.return_value = sample_asdata_shadowserver
+                    
+                    args = Mock()
+                    args.service = "shadowserver"
+                    args.raw = False
+                    args.pause = True
+                    args.address = None
+                    
+                    parser = Mock()
+                    
+                    addresses = ["8.8.8.8", "1.1.1.1"]
+                    await process_addresses_async(addresses, args, parser)
+                    
+                    # Should call sleep once (between the two addresses)
+                    mock_sleep.assert_called_once_with(1)
+
+    @pytest.mark.asyncio
+    async def test_process_addresses_raw_output(self, sample_asdata_shadowserver):
+        """Test processing addresses with raw output."""
+        with patch('aslookup.cli.get_as_data_async') as mock_get_data:
+            with patch('builtins.print') as mock_print:
+                mock_get_data.return_value = sample_asdata_shadowserver
+                
+                args = Mock()
+                args.service = "shadowserver"
+                args.raw = True
+                args.pause = False
+                args.address = None
+                
+                parser = Mock()
+                
+                await process_addresses_async(["8.8.8.8"], args, parser)
+                
+                # Should print the ASData object directly
+                mock_print.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_process_addresses_mixed_results(self, sample_asdata_shadowserver):
+        """Test processing addresses with mixed success/error results."""
+        with patch('aslookup.cli.get_as_data_async') as mock_get_data:
+            with patch('builtins.print') as mock_print:
+                def side_effect(addr, service):
+                    if addr == "8.8.8.8":
+                        return sample_asdata_shadowserver
+                    else:
+                        raise AddressFormatError("Invalid IP")
+                
+                mock_get_data.side_effect = side_effect
+                
+                args = Mock()
+                args.service = "shadowserver"
+                args.raw = False
+                args.pause = False
+                args.address = None
+                
+                parser = Mock()
+                
+                addresses = ["8.8.8.8", "invalid_ip"]
+                await process_addresses_async(addresses, args, parser)
+                
+                # Should print both success and error results
+                assert mock_print.call_count == 2
+
+
+class TestCLIIntegration:
+    """Test CLI integration scenarios."""
+
+    def test_main_single_address_success(self, sample_asdata_shadowserver):
+        """Test main function with single address success."""
+        with patch('aslookup.cli.asyncio.run') as mock_run:
+            with patch('sys.argv', ['as-lookup', '8.8.8.8']):
+                with patch('aslookup.cli.process_addresses_async') as mock_process:
+                    mock_process.return_value = asyncio.Future()
+                    mock_process.return_value.set_result(None)
+                    
+                    main()
+                    
+                    mock_run.assert_called_once()
+
+        """Test main function with stdin input."""
+        with patch('aslookup.cli.asyncio.run') as mock_run:
+            with patch('sys.argv', ['as-lookup']):
+                with patch('aslookup.cli.process_addresses_async') as mock_process:
+                    mock_process.return_value = asyncio.Future()
+                    mock_process.return_value.set_result(None)
+                    
+                    with patch('sys.stdin', StringIO('8.8.8.8\n1.1.1.1\n')):
+                        main()
+                        
+                        mock_run.assert_called_once()
+
+    def test_main_cymru_service(self):
+        """Test main function with Cymru service."""
+        with patch('aslookup.cli.asyncio.run') as mock_run:
+            with patch('sys.argv', ['as-lookup', '--service', 'cymru', '8.8.8.8']):
+                with patch('aslookup.cli.process_addresses_async') as mock_process:
+                    mock_process.return_value = asyncio.Future()
+                    mock_process.return_value.set_result(None)
+                    
+                    main()
+                    
+                    mock_run.assert_called_once()
+
+    def test_main_header_and_raw(self):
+        """Test main function with header and raw output."""
+        with patch('aslookup.cli.asyncio.run') as mock_run:
+            with patch('sys.argv', ['as-lookup', '--header', '--raw', '8.8.8.8']):
+                with patch('aslookup.cli.process_addresses_async') as mock_process:
+                    mock_process.return_value = asyncio.Future()
+                    mock_process.return_value.set_result(None)
+                    
+                    main()
+                    
+                    mock_run.assert_called_once()
+
+    def test_main_empty_stdin(self):
+        """Test main function with empty stdin."""
+        with patch('aslookup.cli.asyncio.run') as mock_run:
+            with patch('sys.argv', ['as-lookup']):
+                with patch('aslookup.cli.process_addresses_async') as mock_process:
+                    mock_process.return_value = asyncio.Future()
+                    mock_process.return_value.set_result(None)
+                    
+                    with patch('sys.stdin', StringIO('')):
+                        main()
+                        
+                        mock_run.assert_called_once()
+
+    def test_main_defanged_input(self):
+        """Test main function with defanged IP input."""
+        with patch('aslookup.cli.asyncio.run') as mock_run:
+            with patch('sys.argv', ['as-lookup']):
+                with patch('aslookup.cli.process_addresses_async') as mock_process:
+                    mock_process.return_value = asyncio.Future()
+                    mock_process.return_value.set_result(None)
+                    
+                    with patch('sys.stdin', StringIO('8[.]8[.]8[.]8\n')):
+                        main()
+                        
+                        mock_run.assert_called_once()

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -1,0 +1,190 @@
+"""Tests for aslookup.exceptions module."""
+
+import pytest
+
+from aslookup.exceptions import (
+    AddressFormatError,
+    LookupError,
+    NoASDataError,
+    NonroutableAddressError,
+)
+
+
+class TestExceptionHierarchy:
+    """Test exception class hierarchy and inheritance."""
+
+    def test_lookup_error_is_base_exception(self):
+        """Test that LookupError is the base exception class."""
+        assert issubclass(LookupError, Exception)
+
+    def test_no_as_data_error_inheritance(self):
+        """Test NoASDataError inherits from LookupError."""
+        assert issubclass(NoASDataError, LookupError)
+        assert issubclass(NoASDataError, Exception)
+
+    def test_nonroutable_address_error_inheritance(self):
+        """Test NonroutableAddressError inherits from LookupError."""
+        assert issubclass(NonroutableAddressError, LookupError)
+        assert issubclass(NonroutableAddressError, Exception)
+
+    def test_address_format_error_inheritance(self):
+        """Test AddressFormatError inherits from LookupError."""
+        assert issubclass(AddressFormatError, LookupError)
+        assert issubclass(AddressFormatError, Exception)
+
+
+class TestExceptionInstantiation:
+    """Test exception instantiation and message handling."""
+
+    def test_lookup_error_creation(self):
+        """Test LookupError can be created with message."""
+        message = "Test lookup error"
+        error = LookupError(message)
+        assert str(error) == message
+        assert isinstance(error, Exception)
+
+    def test_no_as_data_error_creation(self):
+        """Test NoASDataError can be created with message."""
+        message = "No AS data available"
+        error = NoASDataError(message)
+        assert str(error) == message
+        assert isinstance(error, LookupError)
+
+    def test_nonroutable_address_error_creation(self):
+        """Test NonroutableAddressError can be created with message."""
+        message = "Address is not routable"
+        error = NonroutableAddressError(message)
+        assert str(error) == message
+        assert isinstance(error, LookupError)
+
+    def test_address_format_error_creation(self):
+        """Test AddressFormatError can be created with message."""
+        message = "Invalid address format"
+        error = AddressFormatError(message)
+        assert str(error) == message
+        assert isinstance(error, LookupError)
+
+    def test_exceptions_without_message(self):
+        """Test exceptions can be created without message."""
+        errors = [
+            LookupError(),
+            NoASDataError(),
+            NonroutableAddressError(),
+            AddressFormatError(),
+        ]
+        for error in errors:
+            assert isinstance(error, Exception)
+            # Should not raise when converted to string
+            str(error)
+
+
+class TestExceptionRaising:
+    """Test that exceptions can be properly raised and caught."""
+
+    def test_raise_lookup_error(self):
+        """Test raising and catching LookupError."""
+        message = "Test lookup error"
+        with pytest.raises(LookupError) as exc_info:
+            raise LookupError(message)
+        assert str(exc_info.value) == message
+
+    def test_raise_no_as_data_error(self):
+        """Test raising and catching NoASDataError."""
+        message = "No AS data found"
+        with pytest.raises(NoASDataError) as exc_info:
+            raise NoASDataError(message)
+        assert str(exc_info.value) == message
+
+    def test_raise_nonroutable_address_error(self):
+        """Test raising and catching NonroutableAddressError."""
+        message = "RFC 1918 private address"
+        with pytest.raises(NonroutableAddressError) as exc_info:
+            raise NonroutableAddressError(message)
+        assert str(exc_info.value) == message
+
+    def test_raise_address_format_error(self):
+        """Test raising and catching AddressFormatError."""
+        message = "Invalid IP address format"
+        with pytest.raises(AddressFormatError) as exc_info:
+            raise AddressFormatError(message)
+        assert str(exc_info.value) == message
+
+
+class TestExceptionCatching:
+    """Test exception catching with inheritance."""
+
+    def test_catch_specific_as_base(self):
+        """Test that specific exceptions can be caught as base LookupError."""
+        # NoASDataError should be catchable as LookupError
+        with pytest.raises(LookupError):
+            raise NoASDataError("Test message")
+
+        # NonroutableAddressError should be catchable as LookupError
+        with pytest.raises(LookupError):
+            raise NonroutableAddressError("Test message")
+
+        # AddressFormatError should be catchable as LookupError
+        with pytest.raises(LookupError):
+            raise AddressFormatError("Test message")
+
+    def test_catch_multiple_exception_types(self):
+        """Test catching multiple exception types."""
+        exceptions_to_test = [
+            NoASDataError("No data"),
+            NonroutableAddressError("Private IP"),
+            AddressFormatError("Bad format"),
+        ]
+
+        for exception in exceptions_to_test:
+            with pytest.raises((NoASDataError, NonroutableAddressError,
+                               AddressFormatError)):
+                raise exception
+
+    def test_exception_type_identification(self):
+        """Test identifying specific exception types when caught."""
+        try:
+            raise NoASDataError("Test message")
+        except LookupError as e:
+            assert isinstance(e, NoASDataError)
+            assert not isinstance(e, NonroutableAddressError)
+            assert not isinstance(e, AddressFormatError)
+
+        try:
+            raise NonroutableAddressError("Test message")
+        except LookupError as e:
+            assert isinstance(e, NonroutableAddressError)
+            assert not isinstance(e, NoASDataError)
+            assert not isinstance(e, AddressFormatError)
+
+        try:
+            raise AddressFormatError("Test message")
+        except LookupError as e:
+            assert isinstance(e, AddressFormatError)
+            assert not isinstance(e, NoASDataError)
+            assert not isinstance(e, NonroutableAddressError)
+
+
+class TestExceptionMessages:
+    """Test exception message handling and formatting."""
+
+    def test_exception_with_formatted_message(self):
+        """Test exceptions with formatted messages."""
+        ip_addr = "192.168.1.1"
+        message = f"Address {ip_addr} is private"
+        error = NonroutableAddressError(message)
+        assert ip_addr in str(error)
+
+    def test_exception_with_multiple_args(self):
+        """Test exceptions with multiple arguments."""
+        error = LookupError("Primary message", "Secondary info")
+        # Should handle multiple arguments gracefully
+        error_str = str(error)
+        assert "Primary message" in error_str
+
+    def test_exception_repr(self):
+        """Test exception representation."""
+        message = "Test error message"
+        error = AddressFormatError(message)
+        repr_str = repr(error)
+        assert "AddressFormatError" in repr_str
+        assert message in repr_str

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,0 +1,266 @@
+"""Integration tests for aslookup using test data."""
+
+import asyncio
+import pytest
+from unittest.mock import Mock, patch
+
+from aslookup import get_as_data
+from aslookup.exceptions import (
+    AddressFormatError,
+    NoASDataError,
+    NonroutableAddressError,
+)
+from aslookup.lookup import ASData, get_as_data_async
+
+
+class TestIntegrationWithTestData:
+    """Integration tests using the test input data file."""
+
+    def test_valid_public_ipv4_addresses(self):
+        """Test valid public IPv4 addresses from test data."""
+        valid_public_ips = [
+            "1.2.3.4",
+            "198.60.22.22",
+            "8.8.8.8",
+            "212.129.50.243",
+        ]
+        
+        for ip in valid_public_ips:
+            # Mock DNS to avoid actual network calls
+            with patch('dns.resolver.query') as mock_query:
+                mock_answer = Mock()
+                mock_answer.to_text.return_value = (
+                    '"15169 | 8.8.8.0/24 | GOOGLE | US | Google LLC"'
+                )
+                mock_query.return_value = [mock_answer]
+                
+                try:
+                    result = get_as_data(ip, service="shadowserver")
+                    assert isinstance(result, ASData)
+                    assert result.address == ip
+                    assert result.asn is not None
+                except (NoASDataError, NonroutableAddressError):
+                    # Some test IPs might not have AS data or be non-routable
+                    # This is acceptable for integration testing
+                    pass
+
+    def test_valid_public_ipv6_addresses(self):
+        """Test valid public IPv6 addresses from test data."""
+        valid_public_ipv6s = [
+            "2001:4860:4860::8888",
+            "2001:4860:4860::8844",
+            "2606:4700:4700::1111",
+            "2001:4860:4802::2001",
+        ]
+        
+        for ip in valid_public_ipv6s:
+            # Mock DNS to avoid actual network calls
+            with patch('dns.resolver.query') as mock_query:
+                mock_answer = Mock()
+                mock_answer.to_text.return_value = (
+                    '"15169 | 2001:4860:4860::/48 | GOOGLE | US | Google LLC"'
+                )
+                mock_query.return_value = [mock_answer]
+                
+                try:
+                    result = get_as_data(ip, service="shadowserver")
+                    assert isinstance(result, ASData)
+                    assert result.address == ip
+                    assert result.asn is not None
+                except (NoASDataError, NonroutableAddressError):
+                    # Some test IPs might not have AS data or be non-routable
+                    pass
+
+    def test_invalid_ip_addresses_from_test_data(self):
+        """Test invalid IP addresses from test data."""
+        invalid_ips = [
+            "333.12.96.0",  # Invalid IPv4 (octet > 255)
+            "a.b.c.d",      # Non-numeric IPv4
+            "1[.]1[.]1[.]1",  # Defanged IP (should be handled)
+        ]
+        
+        for ip in invalid_ips:
+            if ip == "1[.]1[.]1[.]1":
+                # Defanged IPs should be processed after refanging
+                with patch('dns.resolver.query') as mock_query:
+                    mock_answer = Mock()
+                    mock_answer.to_text.return_value = (
+                        '"13335 | 1.1.1.0/24 | CLOUDFLARE | US | Cloudflare"'
+                    )
+                    mock_query.return_value = [mock_answer]
+                    result = get_as_data(ip, service="shadowserver")
+                    assert result.address == "1.1.1.1"  # Should be refanged
+            else:
+                with pytest.raises(AddressFormatError):
+                    get_as_data(ip)
+
+    def test_private_ip_addresses_from_test_data(self):
+        """Test private/non-routable IP addresses from test data."""
+        private_ips = [
+            "127.0.2.2",     # Loopback
+            "224.0.10.10",   # Multicast
+            "::1",           # IPv6 loopback
+            "fe80::1",       # IPv6 link-local
+            "fc00::1",       # IPv6 unique local
+            "2001:db8::1",   # IPv6 documentation
+        ]
+        
+        for ip in private_ips:
+            with pytest.raises(NonroutableAddressError):
+                get_as_data(ip)
+
+    def test_both_services_integration(self):
+        """Test integration with both Shadowserver and Cymru services."""
+        test_ip = "8.8.8.8"
+        
+        # Test Shadowserver
+        with patch('dns.resolver.query') as mock_query:
+            mock_answer = Mock()
+            mock_answer.to_text.return_value = (
+                '"15169 | 8.8.8.0/24 | GOOGLE | US | Google LLC"'
+            )
+            mock_query.return_value = [mock_answer]
+            
+            result_ss = get_as_data(test_ip, service="shadowserver")
+            assert result_ss.data_source == "shadowserver"
+            assert isinstance(result_ss, ASData)
+        
+        # Test Cymru (requires two DNS queries)
+        with patch('dns.resolver.query') as mock_query:
+            origin_answer = Mock()
+            origin_answer.to_text.return_value = (
+                '"15169 | 8.8.8.0/24 | US | arin | 2000-03-30"'
+            )
+            
+            asn_answer = Mock()
+            asn_answer.to_text.return_value = (
+                '"15169 | US | arin | 2000-03-30 | GOOGLE, US"'
+            )
+            
+            mock_query.side_effect = [[origin_answer], [asn_answer]]
+            
+            result_cymru = get_as_data(test_ip, service="cymru")
+            assert result_cymru.data_source == "cymru"
+            assert isinstance(result_cymru, ASData)
+            assert result_cymru.rir == "arin"
+
+
+class TestEndToEndScenarios:
+    """Test end-to-end scenarios that simulate real usage."""
+
+    def test_mixed_input_processing(self):
+        """Test processing mixed valid/invalid/private IPs."""
+        mixed_ips = [
+            "8.8.8.8",        # Valid public
+            "192.168.1.1",    # Private
+            "invalid_ip",     # Invalid
+            "1.1.1.1",        # Valid public
+        ]
+        
+        results = []
+        for ip in mixed_ips:
+            try:
+                with patch('dns.resolver.query') as mock_query:
+                    mock_answer = Mock()
+                    mock_answer.to_text.return_value = (
+                        '"15169 | 8.8.8.0/24 | GOOGLE | US | Google LLC"'
+                    )
+                    mock_query.return_value = [mock_answer]
+                    result = get_as_data(ip, service="shadowserver")
+                    results.append(("success", ip, result))
+            except AddressFormatError:
+                results.append(("format_error", ip, None))
+            except NonroutableAddressError:
+                results.append(("nonroutable", ip, None))
+            except NoASDataError:
+                results.append(("no_data", ip, None))
+        
+        # Should have mixed results
+        success_count = len([r for r in results if r[0] == "success"])
+        error_count = len([r for r in results if r[0] != "success"])
+        
+        assert success_count > 0
+        assert error_count > 0
+
+    def test_ipv4_and_ipv6_mixed_processing(self):
+        """Test processing mixed IPv4 and IPv6 addresses."""
+        mixed_ips = [
+            "8.8.8.8",                    # IPv4
+            "2001:4860:4860::8888",       # IPv6
+            "1.1.1.1",                    # IPv4
+            "2606:4700:4700::1111",       # IPv6
+        ]
+        
+        results = []
+        for ip in mixed_ips:
+            with patch('dns.resolver.query') as mock_query:
+                mock_answer = Mock()
+                mock_answer.to_text = Mock(return_value=(
+                    '"15169 | 8.8.8.0/24 | GOOGLE | US | Google LLC"'
+                ))
+                mock_query.return_value = [mock_answer]
+                
+                result = get_as_data(ip, service="shadowserver")
+                results.append(result)
+        
+        assert len(results) == 4
+        for result in results:
+            assert isinstance(result, ASData)
+            assert result.asn is not None
+
+    def test_error_recovery_scenarios(self):
+        """Test error recovery in various scenarios."""
+        # Test DNS timeout/error recovery
+        with patch('dns.resolver.query') as mock_query:
+            import dns.resolver
+            mock_query.side_effect = dns.resolver.NXDOMAIN()
+            
+            with pytest.raises(NoASDataError):
+                get_as_data("8.8.8.8", service="shadowserver")
+        
+        # Test malformed DNS response handling
+        with patch('dns.resolver.query') as mock_query:
+            mock_answer = Mock()
+            mock_answer.to_text.return_value = '"malformed response"'
+            mock_query.return_value = [mock_answer]
+            
+            # For Cymru service, this should raise NoASDataError
+            with pytest.raises(NoASDataError):
+                get_as_data("8.8.8.8", service="cymru")
+
+    def test_service_specific_behavior(self):
+        """Test service-specific behavior differences."""
+        test_ip = "8.8.8.8"
+        
+        # Shadowserver returns data in one query
+        with patch('dns.resolver.query') as mock_query:
+            mock_answer = Mock()
+            mock_answer.to_text.return_value = (
+                '"15169 | 8.8.8.0/24 | GOOGLE | US | Google LLC"'
+            )
+            mock_query.return_value = [mock_answer]
+            
+            result_ss = get_as_data(test_ip, service="shadowserver")
+            assert mock_query.call_count == 1
+            assert result_ss.data_source == "shadowserver"
+            assert result_ss.isp == "Google LLC"
+            assert result_ss.rir is None  # Shadowserver doesn't provide RIR
+        
+        # Cymru requires two queries
+        with patch('dns.resolver.query') as mock_query:
+            origin_answer = Mock()
+            origin_answer.to_text.return_value = (
+                '"15169 | 8.8.8.0/24 | US | arin | 2000-03-30"'
+            )
+            
+            asn_answer = Mock()
+            asn_answer.to_text.return_value = (
+                '"15169 | US | arin | 2000-03-30 | GOOGLE, US"'
+            )
+            
+            mock_query.side_effect = [[origin_answer], [asn_answer]]
+            
+            result_cymru = get_as_data(test_ip, service="cymru")
+            assert mock_query.call_count == 2
+            assert result_cymru.data_source == "cymru"
+            assert result_cymru.rir == "arin"

--- a/tests/test_lookup.py
+++ b/tests/test_lookup.py
@@ -1,0 +1,367 @@
+"""Tests for aslookup.lookup module."""
+
+from unittest.mock import Mock, patch
+
+import aiodns.error
+import dns.resolver
+import pytest
+
+from aslookup.exceptions import (
+    AddressFormatError,
+    NoASDataError,
+    NonroutableAddressError,
+)
+from aslookup.lookup import (
+    ASData,
+    format_ipv6_for_dns,
+    get_as_data,
+    get_as_data_async,
+    get_cymru_data,
+    get_ip_version,
+    get_shadowserver_data,
+    validate_ip,
+)
+
+
+class TestIPValidation:
+    """Test IP address validation functions."""
+
+    def test_get_ip_version_ipv4(self, sample_ipv4_address):
+        """Test IP version detection for IPv4."""
+        assert get_ip_version(sample_ipv4_address) == 4
+
+    def test_get_ip_version_ipv6(self, sample_ipv6_address):
+        """Test IP version detection for IPv6."""
+        assert get_ip_version(sample_ipv6_address) == 6
+
+    def test_get_ip_version_invalid(self, invalid_ip_addresses):
+        """Test IP version detection for invalid addresses."""
+        for invalid_ip in invalid_ip_addresses:
+            with pytest.raises(AddressFormatError):
+                get_ip_version(invalid_ip)
+
+    def test_validate_ip_valid_ipv4(self, sample_ipv4_address):
+        """Test validation of valid IPv4 address."""
+        # Should not raise any exception
+        validate_ip(sample_ipv4_address)
+
+    def test_validate_ip_valid_ipv6(self, sample_ipv6_address):
+        """Test validation of valid IPv6 address."""
+        # Should not raise any exception
+        validate_ip(sample_ipv6_address)
+
+    def test_validate_ip_invalid(self, invalid_ip_addresses):
+        """Test validation of invalid IP addresses."""
+        for invalid_ip in invalid_ip_addresses:
+            with pytest.raises(AddressFormatError):
+                validate_ip(invalid_ip)
+
+    def test_validate_ip_private_addresses(self, private_ip_addresses):
+        """Test validation of private/non-routable addresses."""
+        for private_ip in private_ip_addresses:
+            with pytest.raises(NonroutableAddressError):
+                validate_ip(private_ip)
+
+    def test_validate_ip_edge_cases(self):
+        """Test validation edge cases."""
+        # Test with whitespace
+        with pytest.raises(AddressFormatError):
+            validate_ip("  ")
+
+        # Test with None (should raise AttributeError which becomes
+        # AddressFormatError)
+        with pytest.raises((AddressFormatError, AttributeError)):
+            validate_ip(None)
+
+
+class TestIPv6Formatting:
+    """Test IPv6 DNS formatting functions."""
+
+    def test_format_ipv6_for_dns_simple(self):
+        """Test IPv6 DNS formatting for simple address."""
+        addr = "2001:db8::1"
+        result = format_ipv6_for_dns(addr)
+        expected = (
+            "1.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.8.b.d.0.1.0.0.2"
+        )
+        assert result == expected
+
+    def test_format_ipv6_for_dns_full(self):
+        """Test IPv6 DNS formatting for full address."""
+        addr = "2001:0db8:85a3:0000:0000:8a2e:0370:7334"
+        result = format_ipv6_for_dns(addr)
+        expected = (
+            "4.3.3.7.0.7.3.0.e.2.a.8.0.0.0.0.0.0.0.0.3.a.5.8.8.b.d.0.1.0.0.2"
+        )
+        assert result == expected
+
+    def test_format_ipv6_for_dns_loopback(self):
+        """Test IPv6 DNS formatting for loopback address."""
+        addr = "::1"
+        result = format_ipv6_for_dns(addr)
+        expected = (
+            "1.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0"
+        )
+        assert result == expected
+
+
+class TestDataParsing:
+    """Test AS data parsing functions."""
+
+    def test_get_shadowserver_data_basic(self, sample_shadowserver_response):
+        """Test parsing basic Shadowserver response."""
+        extra = {"address": "8.8.8.8"}
+        result = get_shadowserver_data(sample_shadowserver_response, extra)
+
+        assert isinstance(result, ASData)
+        assert result.address == "8.8.8.8"
+        assert result.asn == "15133"
+        assert result.handle == "AS15133"
+        assert result.as_name == "Google LLC"
+        assert result.prefix == "8.8.8.0/24"
+        assert result.cc == "US"
+        assert result.isp == "Google LLC"
+        assert result.data_source == "shadowserver"
+
+    def test_get_shadowserver_data_empty_as_name(self):
+        """Test Shadowserver response with empty AS name."""
+        response = '"12876 | 212.129.0.0/18 |  | FR | Online SAS"'
+        extra = {"address": "212.129.50.243"}
+        result = get_shadowserver_data(response, extra)
+
+        assert result.as_name == "Online SAS"  # Should use ISP name
+        assert result.isp == "Online SAS"
+
+    def test_get_cymru_data_basic(self, sample_cymru_asn_response):
+        """Test parsing basic Team Cymru response."""
+        extra = {"address": "8.8.8.8", "ip_prefix": "8.8.8.0/24"}
+        result = get_cymru_data(sample_cymru_asn_response, extra)
+        
+        assert isinstance(result, ASData)
+        assert result.address == "8.8.8.8"
+        assert result.asn == "15169"
+        assert result.handle == "AS15169"
+        assert result.as_name == "GOOGLE"
+        assert result.prefix == "8.8.8.0/24"
+        assert result.cc == "US"
+        assert result.rir == "arin"
+        assert result.reg_date == "2000-03-30"
+        assert result.data_source == "cymru"
+
+    def test_get_cymru_data_country_code_cleanup(self):
+        """Test Team Cymru response with country code suffix removal."""
+        response = '"15169 | US | arin | 2000-03-30 | GOOGLE, US, US"'
+        extra = {"address": "8.8.8.8"}
+        result = get_cymru_data(response, extra)
+
+        assert result.as_name == "GOOGLE, US"  # Country code suffix removed
+
+    def test_get_shadowserver_data_country_code_cleanup(self):
+        """Test Shadowserver response with country code suffix removal."""
+        response = '"15133 | 8.8.8.0/24 | GOOGLE | US | Google LLC, US"'
+        extra = {"address": "8.8.8.8"}
+        result = get_shadowserver_data(response, extra)
+
+        assert result.as_name == "Google LLC"  # Country code suffix removed
+
+
+class TestASDataLookup:
+    """Test main AS data lookup functions."""
+
+    @patch('dns.resolver.query')
+    def test_get_as_data_shadowserver_success(self, mock_query,
+                                              sample_ipv4_address):
+        """Test successful Shadowserver lookup."""
+        # Mock DNS response
+        mock_answer = Mock()
+        mock_answer.to_text.return_value = (
+            '"15133 | 8.8.8.0/24 | GOOGLE | US | Google LLC"'
+        )
+        mock_query.return_value = [mock_answer]
+
+        result = get_as_data(sample_ipv4_address, service="shadowserver")
+
+        assert isinstance(result, ASData)
+        assert result.address == sample_ipv4_address
+        assert result.asn == "15133"
+        assert result.data_source == "shadowserver"
+
+        # Verify DNS query was made to correct domain
+        mock_query.assert_called_once()
+        call_args = mock_query.call_args[0]
+        assert "origin.asn.shadowserver.org" in call_args[0]
+
+    @patch('dns.resolver.query')
+    def test_get_as_data_cymru_success(self, mock_query, sample_ipv4_address):
+        """Test successful Team Cymru lookup."""
+        # Mock DNS responses for both queries
+        origin_answer = Mock()
+        origin_answer.to_text.return_value = (
+            '"15169 | 8.8.8.0/24 | US | arin | 2000-03-30"'
+        )
+
+        asn_answer = Mock()
+        asn_answer.to_text.return_value = (
+            '"15169 | US | arin | 2000-03-30 | GOOGLE, US"'
+        )
+
+        mock_query.side_effect = [[origin_answer], [asn_answer]]
+
+        result = get_as_data(sample_ipv4_address, service="cymru")
+
+        assert isinstance(result, ASData)
+        assert result.address == sample_ipv4_address
+        assert result.asn == "15169"
+        assert result.data_source == "cymru"
+
+        # Verify both DNS queries were made
+        assert mock_query.call_count == 2
+
+    @patch('dns.resolver.query')
+    def test_get_as_data_ipv6_shadowserver(self, mock_query,
+                                           sample_ipv6_address):
+        """Test IPv6 lookup with Shadowserver."""
+        mock_answer = Mock()
+        mock_answer.to_text.return_value = (
+            '"15169 | 2001:4860:4860::/48 | GOOGLE | US | Google LLC"'
+        )
+        mock_query.return_value = [mock_answer]
+
+        result = get_as_data(sample_ipv6_address, service="shadowserver")
+
+        assert isinstance(result, ASData)
+        assert result.address == sample_ipv6_address
+
+        # Verify IPv6 DNS query format
+        call_args = mock_query.call_args[0]
+        assert "origin6.asn.shadowserver.org" in call_args[0]
+
+    @patch('dns.resolver.query')
+    def test_get_as_data_nxdomain(self, mock_query, sample_ipv4_address):
+        """Test handling of NXDOMAIN DNS response."""
+        mock_query.side_effect = dns.resolver.NXDOMAIN()
+
+        with pytest.raises(NoASDataError):
+            get_as_data(sample_ipv4_address)
+
+    @patch('dns.resolver.query')
+    def test_get_as_data_shadowserver_no_asn(self, mock_query,
+                                             sample_ipv4_address):
+        """Test Shadowserver response with no ASN."""
+        mock_answer = Mock()
+        mock_answer.to_text.return_value = '" | | | | "'
+        mock_query.return_value = [mock_answer]
+
+        with pytest.raises(NoASDataError):
+            get_as_data(sample_ipv4_address, service="shadowserver")
+
+    def test_get_as_data_invalid_ip(self, invalid_ip_addresses):
+        """Test lookup with invalid IP addresses."""
+        for invalid_ip in invalid_ip_addresses:
+            with pytest.raises(AddressFormatError):
+                get_as_data(invalid_ip)
+
+    def test_get_as_data_private_ip(self, private_ip_addresses):
+        """Test lookup with private IP addresses."""
+        for private_ip in private_ip_addresses:
+            with pytest.raises((LookupError, NonroutableAddressError)):
+                get_as_data(private_ip)
+
+    def test_get_as_data_defanged_input(self):
+        """Test lookup with defanged IP address."""
+        defanged_ip = "8[.]8[.]8[.]8"
+
+        with patch('dns.resolver.query') as mock_query:
+            mock_answer = Mock()
+            mock_answer.to_text.return_value = (
+                '"15133 | 8.8.8.0/24 | GOOGLE | US | Google LLC"'
+            )
+            mock_query.return_value = [mock_answer]
+
+            result = get_as_data(defanged_ip)
+            assert result.address == "8.8.8.8"  # Should be refanged
+
+
+class TestAsyncASDataLookup:
+    """Test async AS data lookup functions."""
+
+    @pytest.mark.asyncio
+    @patch('aiodns.DNSResolver')
+    async def test_get_as_data_async_shadowserver_success(
+        self, mock_resolver_class, sample_ipv4_address
+    ):
+        """Test successful async Shadowserver lookup."""
+        # Mock async DNS response
+        mock_resolver = Mock()
+        mock_answer = Mock()
+        mock_answer.text = '"15133 | 8.8.8.0/24 | GOOGLE | US | Google LLC"'
+        
+        # Create an async mock
+        async def mock_query_async(*args, **kwargs):
+            return [mock_answer]
+        
+        mock_resolver.query = mock_query_async
+        mock_resolver_class.return_value = mock_resolver
+
+        result = await get_as_data_async(sample_ipv4_address,
+                                         service="shadowserver")
+
+        assert isinstance(result, ASData)
+        assert result.address == sample_ipv4_address
+        assert result.asn == "15133"
+        assert result.data_source == "shadowserver"
+
+    @pytest.mark.asyncio
+    @patch('aiodns.DNSResolver')
+    async def test_get_as_data_async_cymru_success(
+        self, mock_resolver_class, sample_ipv4_address
+    ):
+        """Test successful async Team Cymru lookup."""
+        # Mock async DNS responses
+        mock_resolver = Mock()
+
+        origin_answer = Mock()
+        origin_answer.text = '"15169 | 8.8.8.0/24 | US | arin | 2000-03-30"'
+
+        asn_answer = Mock()
+        asn_answer.text = '"15169 | US | arin | 2000-03-30 | GOOGLE, US"'
+
+        # Create async mocks with call tracking
+        call_count = 0
+        async def mock_query_async(*args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                return [origin_answer]
+            else:
+                return [asn_answer]
+
+        mock_resolver.query = mock_query_async
+        mock_resolver_class.return_value = mock_resolver
+
+        result = await get_as_data_async(sample_ipv4_address, service="cymru")
+
+        assert isinstance(result, ASData)
+        assert result.address == sample_ipv4_address
+        assert result.asn == "15169"
+        assert result.data_source == "cymru"
+
+    @pytest.mark.asyncio
+    @patch('aiodns.DNSResolver')
+    async def test_get_as_data_async_dns_error(
+        self, mock_resolver_class, sample_ipv4_address
+    ):
+        """Test async lookup with DNS error."""
+        mock_resolver = Mock()
+        mock_resolver.query.side_effect = aiodns.error.DNSError()
+        mock_resolver_class.return_value = mock_resolver
+
+        with pytest.raises(NoASDataError):
+            await get_as_data_async(sample_ipv4_address)
+
+    @pytest.mark.asyncio
+    async def test_get_as_data_async_invalid_ip(self, invalid_ip_addresses):
+        """Test async lookup with invalid IP addresses."""
+        for invalid_ip in invalid_ip_addresses:
+            with pytest.raises(AddressFormatError):
+                await get_as_data_async(invalid_ip)

--- a/tests/test_nop.py
+++ b/tests/test_nop.py
@@ -1,6 +1,0 @@
-"""Tests."""
-
-
-def test_always_passes():
-    """Test that always passes."""
-    assert True

--- a/tox.ini
+++ b/tox.ini
@@ -1,12 +1,15 @@
 [tox]
 requires =
     tox
-env_list = format, lint, py{310,311}
+env_list = format, lint, py{310,311,312,313}
 
 [testenv]
 description = run unit tests
 deps =
     pytest
+    pytest-asyncio
+    pytest-mock
+    pytest-cov
     pytest-sugar
 commands =
     pytest {posargs:tests}


### PR DESCRIPTION
Add support for asynchronous DNS resolution

- Add async concurrency support with aiodns for parallel IP lookups
- Add unit tests
- Increase debug logging detail and more visibility into resolution activity

Closes #12.